### PR TITLE
One approach to solving Sass/Less/Stylus support

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
       if (cssMatch[1] !== 'css') {
         // Wrap the file contents in the component class
         cssFileContents = '.' + podGuid + '{\n' + cssFileContents + '\n}';
+        cssFileContents = cssFileContents.replace(':--component', '&');
 
         // Do extra Sass pre-processing
         var preprocessor = require('./preprocessors/' + cssMatch[1]);

--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "broccoli-writer": "^0.1.1",
-    "walk-sync": "^0.1.3",
     "broccoli-funnel": "^0.2.2",
-    "symlink-or-copy": "^1.0.1",
+    "broccoli-merge-trees": "^0.2.1",
+    "broccoli-writer": "^0.1.1",
     "css": "^2.2.0",
-    "broccoli-merge-trees": "^0.2.1"
+    "node-sass": "^2.0.1",
+    "symlink-or-copy": "^1.0.1",
+    "walk-sync": "^0.1.3"
   }
 }

--- a/preprocessors/sass.js
+++ b/preprocessors/sass.js
@@ -1,0 +1,16 @@
+var sass = require('node-sass');
+
+module.exports = function (fileContents) {
+  // Strip off any curly braces
+  fileContents = fileContents.replace(/\{|\}/g, '');
+
+  // Make sure every line after the first is indented
+  // This ensures it's scoped to the component class
+  fileContents = fileContents.replace(/[\n\r]/g, '\n\r  ');
+
+  var options = {
+    data: fileContents,
+    indentedSyntax: true
+  };
+  return sass.renderSync(options).css;
+}

--- a/preprocessors/scss.js
+++ b/preprocessors/scss.js
@@ -1,0 +1,8 @@
+var sass = require('node-sass');
+
+module.exports = function (fileContents) {
+  var options = {
+    data: fileContents
+  };
+  return sass.renderSync(options).css;
+}

--- a/tests/dummy/app/my-component/styles.css
+++ b/tests/dummy/app/my-component/styles.css
@@ -1,3 +1,0 @@
-.foo {
-  color: blue;
-}

--- a/tests/dummy/app/my-component/styles.scss
+++ b/tests/dummy/app/my-component/styles.scss
@@ -1,4 +1,4 @@
-& {
+:--component {
   border: 1px solid green;
 }
 

--- a/tests/dummy/app/my-component/styles.scss
+++ b/tests/dummy/app/my-component/styles.scss
@@ -1,0 +1,11 @@
+& {
+  border: 1px solid green;
+}
+
+.foo {
+  color: blue;
+
+  .bar {
+    color: red;
+  }
+}

--- a/tests/dummy/app/my-component/template.hbs
+++ b/tests/dummy/app/my-component/template.hbs
@@ -1,1 +1,1 @@
-<div class="foo">this is my component!</div>
+<div class="foo">this is my <span class="bar">component</span>!</div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,3 @@
+{{my-component}}
+
 {{outlet}}


### PR DESCRIPTION
Attempting to address [issue #1](https://github.com/ebryn/ember-component-css/issues/1).

Essentially, when the add-ons preprocessor is parsing CSS-type files we intercept any file that has a non `.css` extension and dynamically load a plugin that knows which preprocessor is needed to generate the CSS from that file.

Ex: if we have `app/my-component/styles.scss` it would hand it to the `preprocessor/scss` plugin and return the file as compiled CSS.

It's worth noting that this approach would require maintaining the various plugins for preprocessors needed, but the other major alternative approach (feeding into the Broccoli pipeline) would also rely on us making sure our output is usable by all other preprocessor add-ons.

Opening this idea up to discussion, I have a rough implementation in place here.