### PR TITLE
Update deprecated API for ember-cli 0.2.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,6 @@ ComponentCSSPreprocessor.prototype.toTree = function(tree, inputPath, outputPath
 };
 
 function monkeyPatch(EmberApp) {
-  var pickFiles   = require('ember-cli/lib/broccoli/custom-static-compiler');
   var upstreamMergeTrees  = require('broccoli-merge-trees');
   var p     = require('ember-cli/lib/preprocessors');
   var preprocessCss = p.preprocessCss;
@@ -166,7 +165,7 @@ function monkeyPatch(EmberApp) {
   EmberApp.prototype.styles = function() {
     var addonTrees = this.addonTreesFor('styles');
     var external = this._processedExternalTree();
-    var styles = pickFiles(this.trees.styles, {
+    var styles = new Funnel(this.trees.styles, {
       srcDir: '/',
       destDir: '/app/styles'
     });


### PR DESCRIPTION
It seems that pickFiles has been deprecated in favour of 'broccoli-funnel', see: https://github.com/ember-cli/ember-cli/blob/master/CHANGELOG.md#022

I am not sure if there is any difference between `this.pickFiles -> require('broccoli-funnel');` and `this.Funnel -> require('broccoli-funnel');`. But doesn't seem to me like there is any.