### PR TITLE
Handle namespaced components

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,13 +53,13 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
     for (var i = 0, l = paths.length; i < l; i++) {
       filepath = paths[i];
       if (!CSS_SUFFIX.test(filepath)) { continue; }
-      var podName = filepath.split('/')[0];
-      var podGuid = podName + '-' + guid();
+      var podPath = filepath.split('/').slice(0, -1);
+      var podGuid = podPath.join('--') + '-' + guid();
       var cssFileContents = fs.readFileSync(path.join(srcDir, filepath)).toString();
       var parsedCss = css.parse(cssFileContents);
       var transformedParsedCSS = transformCSS(podGuid, parsedCss);
       buffer.push(css.stringify(transformedParsedCSS));
-      podLookup[podName] = podGuid;
+      podLookup[podPath.join('/')] = podGuid;
     }
 
     fs.writeFileSync(path.join(destDir, 'pod-styles.css'), buffer.join(''));


### PR DESCRIPTION
This tweak accommodates components that are nested more than one pod deep, rather than assuming they're at the top level. This came in handy for one of the acceptance tests I was putting together for a forthcoming PR.

Note that the generated class name gets a `--` in place of the `/` in the original path. Given the GUID, there shouldn't ever be an actual conflict, but if you think the visual similarity to BEM's "modifier" notation might annoy some, I'm happy to change it.