### PR TITLE
Add stylus support, update readme, and prevent non-CSS styles from being appended to vendor.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,22 @@ A typical component invocation that looks like this:
 will generated markup like:
 
 `<div class="my-component-a34fba"></div>`
+
+### With Preprocessors
+
+To use this addon with another preprocessor (such as Sass or Less), simply import `pod-styles` into your base app stylesheet.
+
+For example, if you're using Sass:
+
+```scss
+// app/styles/app.scss
+@import "pod-styles";
+```
+
+And that is it! The `pod-styles` file is generated during the build and will then be pulled into your other stylesheet to be processed like normal.
+
+**Approved preprocessors:**
+
+ - [`ember-cli-sass`](https://github.com/aexmachina/ember-cli-sass)
+ - [`ember-cli-less`](https://github.com/gdub22/ember-cli-less)
+ - [`ember-cli-stylus`](https://github.com/drewcovi/ember-cli-stylus)

--- a/index.js
+++ b/index.js
@@ -124,7 +124,8 @@ module.exports = {
     this.app = app;
     this.pod = {
       lookup: Object.create(null),
-      styles: ''
+      styles: '',
+      extension: ''
     };
   },
 

--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -23,6 +23,14 @@ var processors = {
     return css.stringify(transformedParsedCSS);
   },
 
+  styl: function(fileContents, podGuid) {
+    fileContents = fileContents.replace(/:--component/g, '&');
+    fileContents = '.' + podGuid + '\n' + fileContents;
+
+    // Indent styles for scoping
+    return fileContents.replace(/\n/g, '\n  ');
+  },
+
   scss: wrapStyles,
   less: wrapStyles
 };
@@ -68,7 +76,6 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
   return readTree(this.inputTree).then(function(srcDir) {
     var paths = walkSync(srcDir);
     var buffer = [];
-    var extension;
     var filepath;
 
     for (var i = 0, l = paths.length; i < l; i++) {
@@ -77,21 +84,21 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
       // Check that it's not a directory
       if (filepath[filepath.length-1] !== '/') {
 
-        if (!extension || extension === 'css') {
-          extension = filepath.substr(filepath.lastIndexOf('.') + 1);
+        if (!pod.extension || pod.extension === 'css') {
+          pod.extension = filepath.substr(filepath.lastIndexOf('.') + 1);
         }
 
         var podPath = filepath.split('/').slice(0, -1);
         var podGuid = podPath.join('--') + '-' + guid();
         var fileContents = fs.readFileSync(path.join(srcDir, filepath)).toString();
 
-        buffer.push(processors[extension](fileContents, podGuid));
+        buffer.push(processors[pod.extension](fileContents, podGuid));
         pod.lookup[podPath.join('/')] = podGuid;
       }
     }
 
     pod.styles = buffer.join('');
-    fs.writeFileSync(path.join(destDir, 'pod-styles.' + extension), pod.styles);
+    fs.writeFileSync(path.join(destDir, 'pod-styles.' + pod.extension), pod.styles);
   });
 };
 

--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -45,12 +45,17 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '});\n';
 
     fs.appendFileSync(path.join(destDir, 'assets', 'vendor.js'), cssInjectionSource);
-    fs.appendFileSync(path.join(destDir, 'assets', 'vendor.css'), pod.styles);
+    
+    // Only if we generated a pod-styles.css file do we need to append to vendor.css
+    if (pod.extension === 'css') {
+      fs.appendFileSync(path.join(destDir, 'assets', 'vendor.css'), pod.styles);
+    }
 
     // Reset the pod for rebuild
     pod = {
       lookup: Object.create(null),
-      styles: ''
+      styles: '',
+      extension: ''
     };
   });
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.8",
-    "ember-cli-sass": "^3.2.2",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
@@ -43,7 +42,9 @@
   ],
   "ember-addon": {
     "before": [
-      "ember-cli-sass"
+      "ember-cli-sass",
+      "ember-cli-less",
+      "ember-cli-stylus"
     ],
     "configPath": "tests/dummy/config"
   },

--- a/tests/dummy/app/my-component/styles.css
+++ b/tests/dummy/app/my-component/styles.css
@@ -4,8 +4,8 @@
 
 .foo {
   color: blue;
+}
 
-  .bar {
-    color: red;
-  }
+.foo .bar {
+  color: red;
 }

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,1 @@
+/* @import "pod-styles"; */

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,1 +1,0 @@
-@import "pod-styles";


### PR DESCRIPTION
Add stylus support, update readme, and prevent non-CSS styles from being appended to vendor.css

Verified that #21 (Less) works and added support for #22 (Stylus). Also fixed an oversight where non-processed stuff (like `.scss` code) was getting appended to `vendor.css`.

Oh, and I removed the `ember-cli-sass` dev dependency. I assume any time we want to test a preprocessor we can just install it locally and remove it when finished.