### PR TITLE
Improve support for SASS source maps

### DIFF
--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -99,15 +99,15 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
         var podGuid = podPath.join('--') + '-' + guid();
         var fileContents = fs.readFileSync(path.join(srcDir, filepath)).toString();
 
-        if(extension === 'scss') {
+        if(pod.extension === 'scss') {
           var outFilepath = filepath;
           // TODO: introduce a useComponentNameAsFileName option which defaults to false
           if (true) {
-            outFilepath = path.join('pod-styles', podPath.join('/') + '.' + extension);
+            outFilepath = path.join('pod-styles', podPath.join('/') + '.' + pod.extension);
           }
 
           mkdirp.sync(path.join(destDir,path.dirname(outFilepath)));
-          fs.writeFileSync(path.join(destDir, outFilepath), processors[extension](fileContents, podGuid));
+          fs.writeFileSync(path.join(destDir, outFilepath), processors[pod.extension](fileContents, podGuid));
 
           buffer.push('@import "' + outFilepath + '"; \r\n');
         } else {

--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -99,7 +99,7 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
         var podGuid = podPath.join('--') + '-' + guid();
         var fileContents = fs.readFileSync(path.join(srcDir, filepath)).toString();
 
-        if(pod.extension === 'scss') {
+        if(pod.extension !== 'css') {
           var outFilepath = filepath;
           // TODO: introduce a useComponentNameAsFileName option which defaults to false
           if (true) {

--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -6,6 +6,7 @@ var walkSync = require('walk-sync');
 var path = require('path');
 var css = require('css');
 var fs = require('fs');
+var mkdirp = require('mkdirp');
 
 var HAS_SELF_SELECTOR = /&|:--component/;
 
@@ -98,7 +99,21 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
         var podGuid = podPath.join('--') + '-' + guid();
         var fileContents = fs.readFileSync(path.join(srcDir, filepath)).toString();
 
-        buffer.push(processors[pod.extension](fileContents, podGuid));
+        if(extension === 'scss') {
+          var outFilepath = filepath;
+          // TODO: introduce a useComponentNameAsFileName option which defaults to false
+          if (true) {
+            outFilepath = path.join('pod-styles', podPath.join('/') + '.' + extension);
+          }
+
+          mkdirp.sync(path.join(destDir,path.dirname(outFilepath)));
+          fs.writeFileSync(path.join(destDir, outFilepath), processors[extension](fileContents, podGuid));
+
+          buffer.push('@import "' + outFilepath + '"; \r\n');
+        } else {
+          buffer.push(processors[pod.extension](fileContents, podGuid));
+        }
+
         pod.lookup[podPath.join('/')] = podGuid;
       }
     }

--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -73,6 +73,7 @@ BrocComponentCssPreprocessor.prototype.constructor = BrocComponentCssPreprocesso
 
 BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
   var pod = this.options.pod;
+  var useComponentNameAsFileName = this.options.useComponentNameAsFileName;
 
   return readTree(this.inputTree).then(function(srcDir) {
     var paths = walkSync(srcDir);
@@ -101,8 +102,7 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
 
         if(pod.extension !== 'css') {
           var outFilepath = filepath;
-          // TODO: introduce a useComponentNameAsFileName option which defaults to false
-          if (true) {
+          if (useComponentNameAsFileName) {
             outFilepath = path.join('pod-styles', podPath.join('/') + '.' + pod.extension);
           }
 

--- a/lib/component-css-preprocessor.js
+++ b/lib/component-css-preprocessor.js
@@ -21,7 +21,10 @@ ComponentCssPreprocessor.prototype.toTree = function(tree) {
   });
 
   // Process the tree from above, outputs pod-styles and pod-lookup
-  var processedTree = new BrocComponentCssPreprocessor(filteredTree, { pod: addon.pod });
+  var processedTree = new BrocComponentCssPreprocessor(filteredTree, {
+   pod: addon.pod,
+   useComponentNameAsFileName: !!addon.app.project.config().useComponentNameAsFileName
+  });
 
   // Merge the processed tree into the original tree to add the `styles` dir back in
   return mergeTrees([tree, processedTree]);

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
-    "glob": "^4.0.5",
-    "mkdirp": "0.5.0"
+    "glob": "^4.0.5"
   },
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.0.5",
+    "mkdirp": "0.5.0"
   },
   "keywords": [
     "ember-addon"
@@ -54,6 +55,7 @@
     "broccoli-writer": "^0.1.1",
     "css": "^2.2.0",
     "ember-cli-version-checker": "^1.0.2",
+    "mkdirp": "^0.5.0",
     "symlink-or-copy": "^1.0.1",
     "walk-sync": "^0.1.3"
   }


### PR DESCRIPTION
Hey,

I've implemented the solution discussed in #24. Additionally I added an option (or at least I wanted to), to allow renaming the ```.scss``` file to the component's name, which seemed slightly more useful than always seeing ```styles.scss``` as source file. This is way non standard and will break editing files through the browser in the workspace, but until that is properly supported by ember-cli this might be a handy thing. I somehow couldn't figure out how to pass options from app settings to the ```write``` function, maybe someone can enlighten me or just send a PR to my fork if it's easier than explaining :-)


BR,
Dominik 