### PR TITLE
Handle components in the `/components` directory.

### DIFF
--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -82,6 +82,12 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
         }
 
         var podPath = filepath.split('/').slice(0, -1);
+
+        // Handle pod-formatted components that are in the 'components' directory
+        if (podPath[0] === 'components') {
+          podPath.shift();
+        }
+
         var podGuid = podPath.join('--') + '-' + guid();
         var fileContents = fs.readFileSync(path.join(srcDir, filepath)).toString();
 

--- a/tests/dummy/app/acceptance/tests/pod-component-in-components/expectation.js
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-components/expectation.js
@@ -1,0 +1,7 @@
+export default {
+  styles: {
+    '.location-explanation': {
+      color: 'rgb(0, 0, 255)'
+    }
+  }
+};

--- a/tests/dummy/app/acceptance/tests/pod-component-in-components/template.hbs
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-components/template.hbs
@@ -1,0 +1,1 @@
+{{pod-component-in-components}}

--- a/tests/dummy/app/acceptance/tests/pod-component-in-pod/expectation.js
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-pod/expectation.js
@@ -1,0 +1,7 @@
+export default {
+  styles: {
+    '.location-explanation': {
+      color: 'rgb(255, 0, 0)'
+    }
+  }
+};

--- a/tests/dummy/app/acceptance/tests/pod-component-in-pod/template.hbs
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-pod/template.hbs
@@ -1,0 +1,1 @@
+{{outer-pod/inner-pod/pod-component-in-pod}}

--- a/tests/dummy/app/acceptance/tests/pod-component-in-root/expectation.js
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-root/expectation.js
@@ -1,0 +1,7 @@
+export default {
+  styles: {
+    '.location-explanation': {
+      color: 'rgb(0, 255, 0)'
+    }
+  }
+};

--- a/tests/dummy/app/acceptance/tests/pod-component-in-root/template.hbs
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-root/template.hbs
@@ -1,0 +1,1 @@
+{{pod-component-in-root}}

--- a/tests/dummy/app/components/pod-component-in-components/styles.css
+++ b/tests/dummy/app/components/pod-component-in-components/styles.css
@@ -1,0 +1,3 @@
+.location-explanation {
+  color: rgb(0, 0, 255);
+}

--- a/tests/dummy/app/components/pod-component-in-components/template.hbs
+++ b/tests/dummy/app/components/pod-component-in-components/template.hbs
@@ -1,0 +1,3 @@
+<span class="location-explanation">
+  This component lives in the <code>components</code> directory.
+</span>

--- a/tests/dummy/app/outer-pod/inner-pod/pod-component-in-pod/styles.css
+++ b/tests/dummy/app/outer-pod/inner-pod/pod-component-in-pod/styles.css
@@ -1,0 +1,3 @@
+.location-explanation {
+  color: rgb(255, 0, 0);
+}

--- a/tests/dummy/app/outer-pod/inner-pod/pod-component-in-pod/template.hbs
+++ b/tests/dummy/app/outer-pod/inner-pod/pod-component-in-pod/template.hbs
@@ -1,0 +1,3 @@
+<span class="location-explanation">
+  This component lives inside a pod, in the <code>outer-pod/inner-pod</code> directory.
+</span>

--- a/tests/dummy/app/pod-component-in-root/styles.css
+++ b/tests/dummy/app/pod-component-in-root/styles.css
@@ -1,0 +1,3 @@
+.location-explanation {
+  color: rgb(0, 255, 0);
+}

--- a/tests/dummy/app/pod-component-in-root/template.hbs
+++ b/tests/dummy/app/pod-component-in-root/template.hbs
@@ -1,0 +1,3 @@
+<span class="location-explanation">
+  This component lives in the root of the <code>podModulePrefix</code>, which for this app is <code>/app</code>.
+</span>


### PR DESCRIPTION
This should fix #28.

It also adds some general acceptance tests for various valid component locations using the default Ember CLI resolver. In the future we might want to consider an interface to support people using custom resolvers. 