### PR TITLE
Remove reference to deprectated cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An Ember CLI addon which allows you to specify CSS inside of component pod direc
 
 ## Installation
 
-`npm install ember-component-css`
+`npm install ember-component-css --save-dev`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An Ember CLI addon which allows you to specify CSS inside of component pod direc
 
 ## Installation
 
-`npm install ember-component-css --save-dev`
+`ember install ember-component-css --save-dev`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An Ember CLI addon which allows you to specify CSS inside of component pod direc
 
 ## Installation
 
-`ember install:npm ember-component-css`
+`npm install ember-component-css`
 
 ## Usage
 


### PR DESCRIPTION
Small tweak to the readme. I hit a deprecation warning when following the setup instructions.