### PR TITLE
[WIP] Namespace all the things

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Your generated CSS output will look something like:
 .my-component-a34fba {
   padding: 2px;
 }
-.my-component-a34fba .urgent {
+.my-component-a34fba-urgent {
   color: red;
 }
 ```
@@ -44,6 +44,12 @@ A typical component invocation that looks like this:
 will generated markup like:
 
 `<div class="my-component-a34fba"></div>`
+
+Within the template for your component, you can reference the generated version of the `urgent` class using the `{{class-for}}` helper:
+
+`<div class="{{class-for 'urgent'}}">Alert!</div>`
+
+If you ever wish to opt out of the namespacing for a particular class, e.g. if you're tweaking the behavior of an existing framework utility class, you can wrap it in the `:--global` pseudoselector.
 
 ### With Preprocessors
 

--- a/app/helpers/class-for.js
+++ b/app/helpers/class-for.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export function classFor(input) {
+  var key = this._debugContainerKey.replace('component:', '');
+  return Ember.COMPONENT_CSS_LOOKUP[key] + '-' + input;
+}
+
+export default Ember.HTMLBars.makeBoundHelper(classFor);

--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -7,8 +7,7 @@ var path = require('path');
 var css = require('css');
 var fs = require('fs');
 
-var HAS_SELF_SELECTOR = /&|:--component/;
-
+var namespaceSelector = require('./namespace-selector');
 var guid = function fn(n) {
   return n ?
            (n ^ Math.random() * 16 >> n/4).toString(16) :
@@ -17,13 +16,13 @@ var guid = function fn(n) {
 
 // Define different processors based on file extension
 var processors = {
-  css: function(fileContents, podGuid) {
+  css: function(fileContents, podPath, podGuid) {
     var parsedCss = css.parse(fileContents);
-    var transformedParsedCSS = transformCSS(podGuid, parsedCss);
+    var transformedParsedCSS = transformCSS(podPath, podGuid, parsedCss);
     return css.stringify(transformedParsedCSS);
   },
 
-  styl: function(fileContents, podGuid) {
+  styl: function(fileContents, podPath, podGuid) {
     fileContents = fileContents.replace(/:--component/g, '&');
     fileContents = '.' + podGuid + '\n' + fileContents;
 
@@ -35,7 +34,7 @@ var processors = {
   less: wrapStyles
 };
 
-function wrapStyles(fileContents, podGuid) {
+function wrapStyles(fileContents, podPath, podGuid) {
   // Replace instances of :--component with '&'
   fileContents = fileContents.replace(/:--component/g, '&');
 
@@ -43,17 +42,19 @@ function wrapStyles(fileContents, podGuid) {
   return '.' + podGuid + '{' + fileContents + '}';
 }
 
-function transformCSS(podGuid, parsedCss) {
+function transformCSS(podPath, podGuid, parsedCss) {
   var rules = parsedCss.stylesheet.rules;
 
   rules.forEach(function(rule) {
     rule.selectors = rule.selectors.map(function(selector) {
-      var selfSelectorMatch = HAS_SELF_SELECTOR.exec(selector);
+      // Replace & with :--component so that it's valid CSS
+      selector = selector.replace(/&/g, ':--component');
 
-      if (selfSelectorMatch) {
-        return selector.replace(selfSelectorMatch[0], '.' + podGuid);
-      } else {
-        return '.' + podGuid + ' ' + selector;
+      try {
+        return namespaceSelector(selector, podGuid);
+      } catch (e) {
+        throw new Error('Invalid selector "' + selector + '" in styles for component ' +
+          podPath + '.\n' + e.message);
       }
     });
   });
@@ -88,18 +89,20 @@ BrocComponentCssPreprocessor.prototype.write = function (readTree, destDir) {
           pod.extension = filepath.substr(filepath.lastIndexOf('.') + 1);
         }
 
-        var podPath = filepath.split('/').slice(0, -1);
+        var podPathSegments = filepath.split('/').slice(0, -1);
 
         // Handle pod-formatted components that are in the 'components' directory
-        if (podPath[0] === 'components') {
-          podPath.shift();
+        if (podPathSegments[0] === 'components') {
+          podPathSegments.shift();
         }
 
-        var podGuid = podPath.join('--') + '-' + guid();
+        var podGuid = podPathSegments.join('--') + '-' + guid();
+        var podPath = podPathSegments.join('/');
+
         var fileContents = fs.readFileSync(path.join(srcDir, filepath)).toString();
 
-        buffer.push(processors[pod.extension](fileContents, podGuid));
-        pod.lookup[podPath.join('/')] = podGuid;
+        buffer.push(processors[pod.extension](fileContents, podPath, podGuid));
+        pod.lookup[podPath] = podGuid;
       }
     }
 

--- a/lib/namespace-selector.js
+++ b/lib/namespace-selector.js
@@ -3,39 +3,53 @@ var SelectorParser = require('css-selector-parser').CssSelectorParser;
 var parser = new SelectorParser()
     .registerAttrEqualityMods('|', '*', '~', '^', '$')
     .registerNestingOperators('>', '~', '+')
-    .registerSelectorPseudos('any', 'not', '--global');
+    .registerSelectorPseudos('matches', 'has', 'not', '--global');
 
-module.exports = function namespaceSelector(selector, prefix) {
+/*
+ * For the given selector string, rewrites all class names to be prefixed by
+ * the given base name, as well as replacing instances of :--component with
+ * that base class.
+ *
+ * Since classnames are the only thing we have direct control over, by default
+ * only they and the :--component pseudoselector are considered valid.
+ * Users may opt out of namespacing for part of a selector by wrapping it in
+ * :--global() pseudoselector. Within that, anything is fair game and we won't
+ * mess with it.
+ */
+module.exports = function namespaceSelector(selector, base) {
   var parsed = parser.parse(selector);
-  console.log('before', JSON.stringify(parsed, null, 2));
-  namespaceClasses(parsed, prefix);
-  console.log('after', JSON.stringify(parsed, null, 2));
+  namespaceClasses(parsed, base);
   return parser.render(parsed);
 };
 
-function namespaceClasses(selector, prefix) {
+function namespaceClasses(selector, base) {
   if (selector.type === 'selectors') {
-    selector.selectors.forEach(function(selector) { namespaceClasses(selector, prefix); });
+    selector.selectors.forEach(function(selector) { namespaceClasses(selector, base); });
   } else if (selector.type === 'ruleSet') {
-    namespaceClasses(selector.rule, prefix);
+    namespaceClasses(selector.rule, base);
   } else if (selector.type === 'rule') {
-    namespaceRule(selector, prefix);
+    namespaceRule(selector, base);
   } else {
     throw new Error('Unknown selector node type: ' + selector.type);
   }
 }
 
-// TODO What exactly do we want to encourage/allow/discourage/disallow? For now, we limit rules
-// to containing only classes, :--component, and the :--global() pseudo.
-function namespaceRule(rule, prefix) {
+// 'Rule' is the selector parser's terminology for whitespace-or-operator separated
+// selector segments, which it arranges into a linked-list-esque structure. For instance,
+// `foo .bar > [baz]` consists of three rules.
+function namespaceRule(rule, base) {
   if (!isValid(rule)) {
     throw new Error('Only class-based selectors can be scoped to a component. ' +
       'If you want to opt out of scoping for a selector segment, you can wrap it in :--global()');
   }
 
+  if (rule.rule) {
+    namespaceRule(rule.rule, base);
+  }
+
   if (hasClasses(rule)) {
     rule.classNames = rule.classNames.map(function(className) {
-      return prefix + '-' + className;
+      return base + '-' + className;
     });
   }
 
@@ -45,23 +59,29 @@ function namespaceRule(rule, prefix) {
     if (rule.pseudos[0].name === '--component') {
       rule.pseudos = [];
       rule.classNames = rule.classNames || [];
-      rule.classNames.push(prefix);
-    } else if (rule.pseudos[0].name === '--global') {
-      var globalRule = rule.pseudos[0].value.rule;
-      if (globalRule.rule) {
-        throw new Error(':--global() can\'t contain sibling or descendant operators.');
-      }
-
-      rule.tagName = globalRule.tagName;
-      rule.classNames = (rule.classNames || []).concat(globalRule.classNames || []);
-      rule.attrs = globalRule.attrs;
-      rule.pseudos = globalRule.pseudos;
+      rule.classNames.push(base);
+    } else {
+      unwrapGlobal(rule);
     }
   }
+}
 
-  if (rule.rule) {
-    namespaceRule(rule.rule, prefix);
-  }
+// Unwrap the contents of a :--global() pseudoselector rule
+function unwrapGlobal(wrapper) {
+  var globalRule = wrapper.pseudos[0].value.rule;
+
+  // Move the attributes of the global rule to this node
+  wrapper.tagName = globalRule.tagName;
+  wrapper.classNames = (wrapper.classNames || []).concat(globalRule.classNames || []);
+  wrapper.attrs = globalRule.attrs;
+  wrapper.pseudos = globalRule.pseudos;
+
+  // Rework the bottom of the sibling/descendant chain to point to the
+  // next rule down from the :--global() wrapper.
+  var deepestRule = globalRule;
+  while (deepestRule.rule) { deepestRule = deepestRule.rule; }
+  deepestRule.rule = wrapper.rule;
+  wrapper.rule = globalRule.rule;
 }
 
 function isValid(rule) {

--- a/lib/namespace-selector.js
+++ b/lib/namespace-selector.js
@@ -1,0 +1,94 @@
+var SelectorParser = require('css-selector-parser').CssSelectorParser;
+
+var parser = new SelectorParser()
+    .registerAttrEqualityMods('|', '*', '~', '^', '$')
+    .registerNestingOperators('>', '~', '+')
+    .registerSelectorPseudos('any', 'not', '--global');
+
+module.exports = function namespaceSelector(selector, prefix) {
+  var parsed = parser.parse(selector);
+  console.log('before', JSON.stringify(parsed, null, 2));
+  namespaceClasses(parsed, prefix);
+  console.log('after', JSON.stringify(parsed, null, 2));
+  return parser.render(parsed);
+};
+
+function namespaceClasses(selector, prefix) {
+  if (selector.type === 'selectors') {
+    selector.selectors.forEach(function(selector) { namespaceClasses(selector, prefix); });
+  } else if (selector.type === 'ruleSet') {
+    namespaceClasses(selector.rule, prefix);
+  } else if (selector.type === 'rule') {
+    namespaceRule(selector, prefix);
+  } else {
+    throw new Error('Unknown selector node type: ' + selector.type);
+  }
+}
+
+// TODO What exactly do we want to encourage/allow/discourage/disallow? For now, we limit rules
+// to containing only classes, :--component, and the :--global() pseudo.
+function namespaceRule(rule, prefix) {
+  if (!isValid(rule)) {
+    throw new Error('Only class-based selectors can be scoped to a component. ' +
+      'If you want to opt out of scoping for a selector segment, you can wrap it in :--global()');
+  }
+
+  if (hasClasses(rule)) {
+    rule.classNames = rule.classNames.map(function(className) {
+      return prefix + '-' + className;
+    });
+  }
+
+  if (hasPseudos(rule)) {
+    // If the rule is valid, we know it has at most one pseudoselector,
+    // which is either :--component or :--global()
+    if (rule.pseudos[0].name === '--component') {
+      rule.pseudos = [];
+      rule.classNames = rule.classNames || [];
+      rule.classNames.push(prefix);
+    } else if (rule.pseudos[0].name === '--global') {
+      var globalRule = rule.pseudos[0].value.rule;
+      if (globalRule.rule) {
+        throw new Error(':--global() can\'t contain sibling or descendant operators.');
+      }
+
+      rule.tagName = globalRule.tagName;
+      rule.classNames = (rule.classNames || []).concat(globalRule.classNames || []);
+      rule.attrs = globalRule.attrs;
+      rule.pseudos = globalRule.pseudos;
+    }
+  }
+
+  if (rule.rule) {
+    namespaceRule(rule.rule, prefix);
+  }
+}
+
+function isValid(rule) {
+  return !hasTagName(rule)
+      && !hasAttrs(rule)
+      && (hasClasses(rule) || isValidPseudo(rule));
+}
+
+function hasTagName(rule) {
+  return !!rule.tagName;
+}
+
+function hasClasses(rule) {
+  return !!(rule.classNames && rule.classNames.length);
+}
+
+function hasAttrs(rule) {
+  return !!(rule.attrs && rule.attrs.length);
+}
+
+function hasPseudos(rule) {
+  return !!(rule.pseudos && rule.pseudos.length); 
+}
+
+function isValidPseudo(rule) {
+  if (!hasPseudos(rule)) { return false; }
+
+  var pseudoName = rule.pseudos[0].name;
+  return rule.pseudos.length === 1 && (pseudoName === '--component' || pseudoName === '--global');
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-writer": "^0.1.1",
     "css": "^2.2.0",
+    "css-selector-parser": "^1.0.4",
     "ember-cli-version-checker": "^1.0.2",
     "symlink-or-copy": "^1.0.1",
     "walk-sync": "^0.1.3"

--- a/tests/dummy/app/acceptance/tests/descendant-namespacing/green-text/template.hbs
+++ b/tests/dummy/app/acceptance/tests/descendant-namespacing/green-text/template.hbs
@@ -1,1 +1,1 @@
-<span class="colored">{{yield}}</span>
+<span class="{{class-for 'colored'}}">{{yield}}</span>

--- a/tests/dummy/app/acceptance/tests/descendant-namespacing/orange-text/template.hbs
+++ b/tests/dummy/app/acceptance/tests/descendant-namespacing/orange-text/template.hbs
@@ -1,1 +1,1 @@
-<span class="colored">{{yield}}</span>
+<span class="{{class-for 'colored'}}">{{yield}}</span>

--- a/tests/dummy/app/acceptance/tests/descendant-namespacing/template.hbs
+++ b/tests/dummy/app/acceptance/tests/descendant-namespacing/template.hbs
@@ -2,7 +2,7 @@
   <span data-test-green>text</span>
 {{/acceptance/tests/descendant-namespacing/green-text}}
 
-<span class="colored">
+<span class="{{class-for 'colored'}}">
   <span data-test-black>text</span>
 </span>
 

--- a/tests/dummy/app/acceptance/tests/pod-component-in-components/expectation.js
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-components/expectation.js
@@ -1,6 +1,6 @@
 export default {
   styles: {
-    '.location-explanation': {
+    '[data-location-explanation]': {
       color: 'rgb(0, 0, 255)'
     }
   }

--- a/tests/dummy/app/acceptance/tests/pod-component-in-pod/expectation.js
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-pod/expectation.js
@@ -1,6 +1,6 @@
 export default {
   styles: {
-    '.location-explanation': {
+    '[data-location-explanation]': {
       color: 'rgb(255, 0, 0)'
     }
   }

--- a/tests/dummy/app/acceptance/tests/pod-component-in-root/expectation.js
+++ b/tests/dummy/app/acceptance/tests/pod-component-in-root/expectation.js
@@ -1,6 +1,6 @@
 export default {
   styles: {
-    '.location-explanation': {
+    '[data-location-explanation]': {
       color: 'rgb(0, 255, 0)'
     }
   }

--- a/tests/dummy/app/acceptance/tests/selector-namespacing/expectation.js
+++ b/tests/dummy/app/acceptance/tests/selector-namespacing/expectation.js
@@ -1,0 +1,15 @@
+const MAGENTA = { color: 'rgb(255, 0, 255)' };
+const GREEN = { color: 'rgb(0, 255, 0)' };
+const BLUE = { color: 'rgb(0, 0, 255)' };
+const CYAN = { color: 'rgb(0, 255, 255)' };
+
+export default {
+  styles: {
+    '[data-component-text]': MAGENTA,
+    '[data-namespaced-green]': GREEN,
+    '[data-global-child]': CYAN,
+    '[data-global-green]': MAGENTA,
+    '[data-global-blue]': BLUE,
+    '[data-namespaced-blue]': MAGENTA
+  }
+};

--- a/tests/dummy/app/acceptance/tests/selector-namespacing/styles.css
+++ b/tests/dummy/app/acceptance/tests/selector-namespacing/styles.css
@@ -1,0 +1,15 @@
+:--component {
+  color: rgb(255, 0, 255);
+}
+
+.green-text {
+  color: rgb(0, 255, 0);
+}
+
+.green-text > :--global(span) {
+  color: rgb(0, 255, 255);
+}
+
+:--global(.global-blue-text) {
+  color: rgb(0, 0, 255);
+}

--- a/tests/dummy/app/acceptance/tests/selector-namespacing/template.hbs
+++ b/tests/dummy/app/acceptance/tests/selector-namespacing/template.hbs
@@ -1,0 +1,26 @@
+<div data-component-text>
+  This text should be magenta, inherited from the component's class.
+</div>
+
+<div data-namespaced-green class="{{class-for 'green-text'}}">
+  This text should be green, due to a namespaced <code>green-text</code> class.
+
+  <span data-global-child>
+    This text should be cyan, as an unscoped <code>&lt;span&gt;</code> descendant
+    of the <code>.green-text</code> element.
+  </span>
+</div>
+
+<div data-global-green class="green-text">
+  This text should still be magenta, because there is no global
+  <code>green-text</code> class.
+</div>
+
+<div data-global-blue class="global-blue-text">
+  This text should be blue due to an un-namespaced <code>global-blue-text</code> class.
+</div>
+
+<div data-namespaced-blue class="{{class-for 'global-blue-text'}}">
+  This text should still be magenta, because there is no namespaced
+  <code>global-blue-text</code> class.
+</div>

--- a/tests/dummy/app/components/pod-component-in-components/template.hbs
+++ b/tests/dummy/app/components/pod-component-in-components/template.hbs
@@ -1,3 +1,3 @@
-<span class="location-explanation">
+<span class="{{class-for 'location-explanation'}}" data-location-explanation>
   This component lives in the <code>components</code> directory.
 </span>

--- a/tests/dummy/app/my-component/template.hbs
+++ b/tests/dummy/app/my-component/template.hbs
@@ -1,1 +1,1 @@
-<div class="foo">this is my <span class="bar">component</span>!</div>
+<div class="{{class-for 'foo'}}">this is my <span class="{{class-for 'bar'}}">component</span>!</div>

--- a/tests/dummy/app/outer-pod/inner-pod/pod-component-in-pod/template.hbs
+++ b/tests/dummy/app/outer-pod/inner-pod/pod-component-in-pod/template.hbs
@@ -1,3 +1,3 @@
-<span class="location-explanation">
+<span class="{{class-for 'location-explanation'}}" data-location-explanation>
   This component lives inside a pod, in the <code>outer-pod/inner-pod</code> directory.
 </span>

--- a/tests/dummy/app/pod-component-in-root/template.hbs
+++ b/tests/dummy/app/pod-component-in-root/template.hbs
@@ -1,3 +1,3 @@
-<span class="location-explanation">
+<span class="{{class-for 'location-explanation'}}" data-location-explanation>
   This component lives in the root of the <code>podModulePrefix</code>, which for this app is <code>/app</code>.
 </span>


### PR DESCRIPTION
This PR isn't ready to merge yet, but I'm hoping to use it to start a discussion. In a similar vein to @ebryn's original [class-for-helper branch](https://github.com/ebryn/ember-component-css/tree/class-for-helper), this change causes all class names in a component's stylesheet to be rewritten individually, rather than requiring them to be descendants of the component's class.

In order to generate the correct class names on the markup side, a `{{class-for}}` template helper is exposed. You can take a look at [the acceptance tests](https://github.com/ebryn/ember-component-css/pull/39/files#diff-12) for examples of this in action.

Before this lands, I have a handful of open questions that I'd love to get feedback on. Please bear in mind I'm somewhere between "not wedded to" and "not even particularly fond of" most aspects of this implementation, so if you've got ideas for a better approach or form factor for any of it, I'm all ears.

#### Old Behavior
Do we want to keep today's nesting behavior as an optional mode? I could imagine allowing users to configure a strategy for style isolation, with options like `nesting`, `munging`, and (maybe someday) the direct injection proposed in [this comment](https://github.com/ebryn/ember-component-css/issues/6#issuecomment-86359214).

#### Preprocessor Support
Supporting this class name munging with preprocessors is definitely an interesting challenge, given that we want to avoid explicitly invoking the other preprocessors. I have a couple ideas for how we might be able to pull it off, but I'm not sure yet whether any of them are feasible given Ember CLI's pre/postprocessor infrastructure as it stands. If anyone has any ideas or is interested in brainstorming, please give me a shout!

#### Escape Hatch
Inevitably people are going to come up with reasons they need to style against some globally-consistent class name for something, and will want to selectively opt-out of namespacing. I played with a couple different ideas for how to accomplish this, and landed on the idea of a special pseudoselector that could be used to "escape" the namespacing:

```css
:--global(.my-unmunged-class) {}
```

It has the advantage of being syntactically-valid CSS, and the idea of pseudoselectors altering the semantics of their arguments isn't unheard of (think `:not` or CSS4's proposed `:matches`). It's also just ugly enough that people hopefully won't overuse it :wink:


#### Valid Selectors
As this currently stands, only selectors composed of classes and the special `:--component` and `:--global` pseudos are considered valid; anything else will throw an exception during processing. This means things like the following are currently illegal:

```css
.my-namespaced-class:hover {}
```

The exception to this rule is the contents of the `:--global` escape – within it, anything is fair game. That means you _could_ use `:--global` to squeeze in the above `:hover`:

```css
.my-namespaced-class:--global(:hover) {}
```
That feels like an overzealous restriction, though. It seems as though pseudoclasses, attribute selectors, etc., are fine so long as they're not in isolation. So `:hover {}` by itself is illegal, but `.my-class:hover {}` and `&:hover {}` would be ok.


#### Valid Escaped Selectors
I mentioned above that the contents of the `:--global()` escape are currently anything-goes. That means it's technically possible to write a rule like this and get away with it:

```css
:--global(div li:nth-child(5) > span) {}
```

You could imagine enforcing that the contents of a `:--global` can only be class names; not sure whether that's overly restrictive or not. 


#### Testing
I added an acceptance test to verify the high-level functionality, but it definitely feels like unit testing for the namespacing logic is in order. If anybody has experience testing the Node-based build portions of an addon alongside the Ember CLI "app-side" testing, I'd love input.