### PR TITLE
Add support for .sass extension

### DIFF
--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -23,17 +23,21 @@ var processors = {
     return css.stringify(transformedParsedCSS);
   },
 
-  styl: function(fileContents, podGuid) {
-    fileContents = fileContents.replace(/:--component/g, '&');
-    fileContents = '.' + podGuid + '\n' + fileContents;
-
-    // Indent styles for scoping
-    return fileContents.replace(/\n/g, '\n  ');
-  },
+  styl: indentStyles,
+  sass: indentStyles,
 
   scss: wrapStyles,
   less: wrapStyles
 };
+
+function indentStyles(fileContents, podGuid) {
+  fileContents = fileContents.replace(/:--component/g, '&');
+  fileContents = '.' + podGuid + '\n' + fileContents;
+
+  // Indent styles for scoping and make sure it ends with a
+  // newline that is not indented
+  return fileContents.replace(/\n/g, '\n  ') + '\n';
+}
 
 function wrapStyles(fileContents, podGuid) {
   // Replace instances of :--component with '&'


### PR DESCRIPTION
Address #33. Should also fix an uncaught issue with `.styl` files as well (if you had multiple files, the indentation was incorrect due to a potential missing newline).