### PR TITLE
Fix production builds

### DIFF
--- a/lib/component-css-preprocessor.js
+++ b/lib/component-css-preprocessor.js
@@ -11,20 +11,28 @@ function ComponentCssPreprocessor(options) {
   this.options = options || {};
 }
 
-ComponentCssPreprocessor.prototype.toTree = function(tree) {
+ComponentCssPreprocessor.prototype.toTree = function(tree, inputPath) {
   var addon = this.options.addon;
 
   // Filter out just the stylesheets in pods
-  var filteredTree = new Funnel(tree, {
+  var podStylesTree = new Funnel(tree, {
     srcDir: addon.podDir() || 'app',
     exclude: [/^styles/]
   });
 
   // Process the tree from above, outputs pod-styles and pod-lookup
-  var processedTree = new BrocComponentCssPreprocessor(filteredTree, { pod: addon.pod });
+  var processedTree = new BrocComponentCssPreprocessor(podStylesTree, { pod: addon.pod });
+
+  // Looks weird, but essentially we funnel the files from 'app/styles'
+  // to 'app/styles'. This way other preprocessors work fine, but we filter
+  // out non-style files.
+  var nonPodStylesTree = new Funnel(tree, {
+    srcDir: inputPath,
+    destDir: inputPath
+  });   
 
   // Merge the processed tree into the original tree to add the `styles` dir back in
-  return mergeTrees([tree, processedTree]);
+  return mergeTrees([nonPodStylesTree, processedTree]);
 };
 
 module.exports = ComponentCssPreprocessor;


### PR DESCRIPTION
Addresses #40.

The issue with `production` builds was being caused by extra JS files being included during the minification step. This was happening because the tree we were returning from our `ComponentCssPreprocessor` included almost the entire project. That is because we needed access to folders other than `app/styles`, which is normally what gets filtered down to in other CSS preprocessors. That was fixable by a simple funnel.

Tested to make sure it worked with `ember-cli-sass` and vanilla CSS.