### PR TITLE
Find uglified vendor.js files to append to

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -44,7 +44,10 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '  }\n' +
                              '});\n';
 
-    fs.appendFileSync(path.join(destDir, 'assets', 'vendor.js'), cssInjectionSource);
+    // Find the vendor.js file in assets so we can append the component lookup JS
+    var assetFiles = fs.readdirSync(path.join(destDir, 'assets'));
+    var vendorjs = assetFiles.filter(function(i){ return i.match(/vendor.*?\.js/) })[0];
+    fs.appendFileSync(path.join(destDir, 'assets', vendorjs), cssInjectionSource);
     
     // Only if we generated a pod-styles.css file do we need to append to vendor.css
     if (pod.extension === 'css') {


### PR DESCRIPTION
The ComponentCssPostprocessor was hard-coded to write to
dist/assets/vendor.js, which meant that it was putting the required code
in that file even if the actual uglified vendor files was named
vendor-abc123.js or whatever.

Fixes #52