### PR TITLE
Include components from addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ function monkeyPatch(EmberApp) {
       destDir: '/app/styles'
     });
 
-    var podStyles = new Funnel(this.trees.app, {
+    var allTrees = [this.trees.app].concat(this.addonTreesFor('app'));
+    var podStyles = new Funnel(mergeTrees(allTrees, {overwrite: true}), {
       include: this._podStylePatterns(),
       exclude: [ /^styles/ ],
       destDir: '/app',


### PR DESCRIPTION
This small change ensures that the components from addons will be found and added to the component lookup table that sets unique classes on each component so that component styles will be applied correctly.

Fixes #46