### PR TITLE
recalculate vendor.js hash

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -18,6 +18,7 @@ ComponentCssPostprocessor.prototype.constructor = ComponentCssPostprocessor;
 
 ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
   var pod = this.options.addon.pod;
+  var hashFn = this.inputTree['inputTree'] && this.inputTree['inputTree'].hashFn;
 
   return readTree(this.inputTree).then(function(srcDir) {
     var paths = walkSync(srcDir);
@@ -53,8 +54,22 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
 
     // Find the vendor.js file in assets so we can append the component lookup JS
     var assetFiles = fs.readdirSync(path.join(destDir, 'assets'));
-    var vendorjs = assetFiles.filter(function(i){ return i.match(/vendor.*?\.js/) })[0];
-    fs.appendFileSync(path.join(destDir, 'assets', vendorjs), cssInjectionSource);
+    var vendorjs = assetFiles.filter(function(i){ return i.match(/vendor.*?\.js/); })[0];
+    var vendorjsPath = path.join(destDir, 'assets', vendorjs);
+    fs.appendFileSync(vendorjsPath, cssInjectionSource);
+
+    if (hashFn && vendorjs.indexOf('-') > -1){
+      var vendorJsContent = fs.readFileSync(vendorjsPath, { encoding: 'utf8' });
+      var hash = hashFn(vendorJsContent);
+      var newFileName = 'vendor-' + hash + '.js';
+
+      fs.renameSync(vendorjsPath, vendorjsPath.replace(vendorjs, newFileName));
+
+      var indexHtmlName = path.join(destDir, 'index.html');
+      var indexHtmlContent = fs.readFileSync(indexHtmlName, { encoding: 'utf8' });
+      indexHtmlContent = indexHtmlContent.replace(vendorjs, newFileName);
+      fs.writeFileSync(indexHtmlName, indexHtmlContent);
+    }
 
     // Only if we generated a pod-styles.css file do we need to append to vendor.css
     if (pod.extension === 'css') {


### PR DESCRIPTION
Currently after appending `cssInjectionSource` to already fingerprinted `vendor.js`, file is not re-fingerprinted, and this causes a bug when ember app is being delivered via CDNs and the latter has http cache configured (e. g. `aws s3` and `cloudfront`) - css namespace classes change, but browser gets an older version of a file (because fingerprint hasn't changed). This PR fixes this.