### PR TITLE
Use ember-cli-preprocess-registry model

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var ComponentCssPostprocessor = require('./lib/component-css-postprocessor');
 
 function monkeyPatch(EmberApp) {
   var upstreamMergeTrees = require('broccoli-merge-trees');
-  var p = require('ember-cli/lib/preprocessors');
+  var p = require('ember-cli-preprocess-registry/preprocessors');
   var preprocessCss = p.preprocessCss;
   var preprocessMinifyCss = p.preprocessMinifyCss;
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
+    "ember-cli-preprocess-registry": "^1.0.1",
     "expect.js": "^0.3.1",
     "express": "^4.8.5",
     "glob": "^4.0.5",


### PR DESCRIPTION
The package just fails using `ember-cli@1.13.1` because `ember-cli/lib/preprocessor` doesn't exist anymore. 

I saw this PR (https://github.com/ember-cli/ember-cli/commit/3438f568a9cae217297f1675787aa2d5711261d5) and brought over the same package