### PR TITLE
Fixes nested component class lookup for components that use '.' instead of '/'

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -39,6 +39,7 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '  lookupFactory: function(name, container) {\n' +
                              '    var Component = this._super(name, container);\n' +
                              '    if (!Component) { return; }\n' +
+                             '    name = name.replace(".","/");\n' +
                              '    if (Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
                              '      return Component;\n' +
                              '    }\n' +
@@ -49,6 +50,7 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '  componentFor: function(name, container) {\n' +
                              '    var Component = this._super(name, container);\n' +
                              '    if (!Component) { return; }\n' +
+                             '    name = name.replace(".","/");\n' +
                              '    if (Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
                              '      return Component;\n' +
                              '    }\n' +


### PR DESCRIPTION
Nested components that use the `.` separator weren't being resolved correctly. With angle-bracket components, dot style will probably become much more common.