### PR TITLE
Fix using multiple self selectors

### DIFF
--- a/lib/broc-component-css-preprocessor.js
+++ b/lib/broc-component-css-preprocessor.js
@@ -7,7 +7,7 @@ var path = require('path');
 var css = require('css');
 var fs = require('fs');
 
-var HAS_SELF_SELECTOR = /&|:--component/;
+var MATCH_SELF_SELECTORS = /&|:--component/g;
 
 var guid = function fn(n) {
   return n ?
@@ -52,10 +52,10 @@ function transformCSS(podGuid, parsedCss) {
 
   rules.forEach(function(rule) {
     rule.selectors = rule.selectors.map(function(selector) {
-      var selfSelectorMatch = HAS_SELF_SELECTOR.exec(selector);
+      var selfSelectorMatch = MATCH_SELF_SELECTORS.exec(selector);
 
       if (selfSelectorMatch) {
-        return selector.replace(selfSelectorMatch[0], '.' + podGuid);
+        return selector.replace(MATCH_SELF_SELECTORS, '.' + podGuid);
       } else {
         return '.' + podGuid + ' ' + selector;
       }

--- a/tests/dummy/app/acceptance/tests/multiple-self-selector/component.js
+++ b/tests/dummy/app/acceptance/tests/multiple-self-selector/component.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: 'self foo bar'
+});

--- a/tests/dummy/app/acceptance/tests/multiple-self-selector/expectation.js
+++ b/tests/dummy/app/acceptance/tests/multiple-self-selector/expectation.js
@@ -1,0 +1,10 @@
+export default {
+  styles: {
+    '.self.bar': {
+      fontWeight: 'bold'
+    },
+    '.self.foo': {
+      fontWeight: 'bold'
+    }
+  }
+};

--- a/tests/dummy/app/acceptance/tests/multiple-self-selector/styles.css
+++ b/tests/dummy/app/acceptance/tests/multiple-self-selector/styles.css
@@ -1,0 +1,3 @@
+&.foo, &.bar {
+  font-weight: bold;
+}


### PR DESCRIPTION
Using the `&` or `:--component` selector multiple times doesn't work.

My use case was where I had the same style for a selected and hover state like this:

```css
:--component:hover, :--component.active {
  background-color: red;
}
```

Which would only replace the first `:--component` selector.
