### PR TITLE
Never add `undefined` to `classNames`

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -39,8 +39,7 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '  lookupFactory: function(name, container) {\n' +
                              '    var Component = this._super(name, container);\n' +
                              '    if (!Component) { return; }\n' +
-                             '    name = name.replace(".","/");\n' +
-                             '    if (Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
+                             '    if (!Ember.COMPONENT_CSS_LOOKUP[name] || Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
                              '      return Component;\n' +
                              '    }\n' +
                              '    return Component.reopen({\n' +
@@ -50,8 +49,7 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
                              '  componentFor: function(name, container) {\n' +
                              '    var Component = this._super(name, container);\n' +
                              '    if (!Component) { return; }\n' +
-                             '    name = name.replace(".","/");\n' +
-                             '    if (Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
+                             '    if (!Ember.COMPONENT_CSS_LOOKUP[name] || Component.prototype.classNames.indexOf(Ember.COMPONENT_CSS_LOOKUP[name]) > -1){\n' +
                              '      return Component;\n' +
                              '    }\n' +
                              '    return Component.reopen({\n' +


### PR DESCRIPTION
This could break components if they depend on `classNames` not having
`null` or `undefined` in it.