### PR TITLE
Fix fingerprinted css by rehashing in postprocess

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -19,6 +19,9 @@ ComponentCssPostprocessor.prototype.constructor = ComponentCssPostprocessor;
 ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
   var pod = this.options.addon.pod;
   var hashFn = this.inputTree['inputTree'] && this.inputTree['inputTree'].hashFn;
+  var isHashed = function(fileName) {
+    return hashFn && fileName.indexOf('-') > -1
+  };
 
   return readTree(this.inputTree).then(function(srcDir) {
     var paths = walkSync(srcDir);
@@ -62,26 +65,25 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
 
     // Find the vendor.js file in assets so we can append the component lookup JS
     var assetFiles = fs.readdirSync(path.join(destDir, 'assets'));
-    var vendorjs = assetFiles.filter(function(i){ return i.match(/vendor.*?\.js/); })[0];
+    var vendorjs = getVendorFile(assetFiles, 'js');
     var vendorjsPath = path.join(destDir, 'assets', vendorjs);
     fs.appendFileSync(vendorjsPath, cssInjectionSource);
 
-    if (hashFn && vendorjs.indexOf('-') > -1){
-      var vendorJsContent = fs.readFileSync(vendorjsPath, { encoding: 'utf8' });
-      var hash = hashFn(vendorJsContent);
-      var newFileName = 'vendor-' + hash + '.js';
-
-      fs.renameSync(vendorjsPath, vendorjsPath.replace(vendorjs, newFileName));
-
-      var indexHtmlName = path.join(destDir, 'index.html');
-      var indexHtmlContent = fs.readFileSync(indexHtmlName, { encoding: 'utf8' });
-      indexHtmlContent = indexHtmlContent.replace(vendorjs, newFileName);
-      fs.writeFileSync(indexHtmlName, indexHtmlContent);
+    if (isHashed(vendorjs)) {
+      var newJsFileName = rehash(hashFn, destDir, vendorjs)
+      rewriteIndex(destDir, vendorjs, newJsFileName);
     }
 
     // Only if we generated a pod-styles.css file do we need to append to vendor.css
     if (pod.extension === 'css') {
-      fs.appendFileSync(path.join(destDir, 'assets', 'vendor.css'), pod.styles);
+      var vendorcss = getVendorFile(assetFiles, 'css');
+      var vendorcssPath = path.join(destDir, 'assets', vendorcss);
+      fs.appendFileSync(vendorcssPath, pod.styles);
+
+      if (isHashed(vendorcss)) {
+        var newCssFileName = rehash(hashFn, destDir, vendorcss);
+        rewriteIndex(destDir, vendorjs, newCssFileName);
+      }
     }
 
     // Reset the pod for rebuild
@@ -92,5 +94,31 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
     };
   });
 };
+
+function getVendorFile(assets, ext) {
+  var r = new RegExp('vendor.*?\.' + ext)
+  return assets.filter(function(a) {
+    return r.test(a);
+  })[0];
+}
+
+function rewriteIndex(destDir, oldFileName, newFileName) {
+  var indexHtmlName = path.join(destDir, 'index.html');
+  var indexHtmlContent = fs.readFileSync(indexHtmlName, { encoding: 'utf8' });
+  indexHtmlContent = indexHtmlContent.replace(oldFileName, newFileName);
+  fs.writeFileSync(indexHtmlName, indexHtmlContent);
+}
+
+function rehash(hashFn, destDir, fileName) {
+  var ext         = fileName.split('.').slice(-1)[0];
+  var oldFilePath = path.join(destDir, 'assets', fileName);
+  var content     = fs.readFileSync(oldFilePath, { encoding: 'utf8' });
+  var hash        = hashFn(content);
+  var newFileName = file + '-' + hash + '.' + ext;
+
+  fs.renameSync(oldFilePath, oldFilePath.replace(fileName, newFileName))
+
+  return newFileName
+}
 
 module.exports = ComponentCssPostprocessor;


### PR DESCRIPTION
Production builds currently don't work when using plain CSS as it appends to `vendor.css` instead of the fingerprinted version. This change should fix this.