### PR TITLE
Fix `hashFn` reference

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -18,7 +18,9 @@ ComponentCssPostprocessor.prototype.constructor = ComponentCssPostprocessor;
 
 ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
   var pod = this.options.addon.pod;
-  var hashFn = this.inputTree['inputTree'] && this.inputTree['inputTree'].hashFn;
+  var hashFn = this.inputTree['inputTree']
+    && this.inputTree['inputTree']._inputNodes
+    && this.inputTree['inputTree']._inputNodes[0].hashFn;
 
   return readTree(this.inputTree).then(function(srcDir) {
     var paths = walkSync(srcDir);


### PR DESCRIPTION
Something has changed in the structure of the input trees, `hashFn` was always returning `undefined` so we would have the same hash on our `vendor.js` file but not the same content which is bad! I tested in ember-cli `2.3.0-beta.1` and `1.13.8` and both work as expected.