### PR TITLE
Switched back to the previous class name preprocessing

### DIFF
--- a/lib/pod-style.js
+++ b/lib/pod-style.js
@@ -1,7 +1,7 @@
 var Filter = require('broccoli-persistent-filter');
 var componentNames = require('./component-names.js');
-var postcss = require('postcss');
-var postcssSelectorNamespace = require('postcss-selector-namespace')
+var processStratagies = require('./preprocess-class-names');
+var path = require('path');
 
 module.exports = PodStyles;
 
@@ -15,10 +15,21 @@ function PodStyles(inputTree, options) {
   this.extensions = options.extensions;
 }
 
-PodStyles.prototype.processString = function(string, path) {
-  return postcss().use(postcssSelectorNamespace({
-            selfSelector: /&|:--component/,
-            namespace: '.' + componentNames.class(path),
-            ignoreRoot: false
-          })).process(string).css;
+PodStyles.prototype.processString = function(contents, stylePath) {
+  var extention = path.extname(stylePath),
+      className = componentNames.class(stylePath);
+      strategy = 'default';
+
+  switch (extention) {
+    case '.styl':
+    case '.sass':
+      strategy = 'indentation';
+      break;
+    case '.less':
+    case '.scss':
+      strategy = 'wrap';
+      break;
+  }
+
+  return processStratagies[strategy](contents, className);
 };

--- a/lib/preprocess-class-names.js
+++ b/lib/preprocess-class-names.js
@@ -1,0 +1,30 @@
+var postcss = require('postcss');
+var postcssSelectorNamespace = require('postcss-selector-namespace')
+var os = require('os');
+
+module.exports = {
+  indentation: function(contents, className) {
+    contents = contents.replace(/:--component/g, '&');
+    contents = '.' + className + os.EOL + contents;
+
+    // Indent styles for scoping and make sure it ends with a
+    // newline that is not indented
+    return contents.replace(new RegExp(os.EOL, 'g'), os.EOL + '  ') + os.EOL;
+  },
+
+  wrap: function(contents, className) {
+    // Replace instances of :--component with '&'
+    contents = contents.replace(/:--component/g, '&');
+
+    // Wrap the styles inside the generated class
+    return '.' + className + '{' + contents + '}';
+  },
+
+  default: function(contents, className) {
+    return postcss().use(postcssSelectorNamespace({
+              selfSelector: /&|:--component/,
+              namespace: '.' + className,
+              ignoreRoot: false
+            })).process(contents).css;
+  }
+};


### PR DESCRIPTION
 This is separated into .styl .sass .scss and .less fixes #126 and #127

* Note *
After tests are updated, we can try to find a more unified verson of the the class name preprocessing
for more speed and better parity support