### PR TITLE
moving to a 'private' class name

### DIFF
--- a/lib/component-names.js
+++ b/lib/component-names.js
@@ -1,8 +1,12 @@
+var md5 = require('md5');
+
 module.exports = {
   path: function(actualPath) {
     return actualPath.substr(0, actualPath.lastIndexOf("/")).replace('components/', '');
   },
   class: function(modifiedPath) {
-    return '_' + this.path(modifiedPath).replace(/\//g, '__');
+    var seperator = '__';
+        className = seperator + this.path(modifiedPath).replace(/\//g, seperator);
+    return className + seperator + md5(className).slice(-5);
   }
 };

--- a/lib/component-names.js
+++ b/lib/component-names.js
@@ -3,6 +3,6 @@ module.exports = {
     return actualPath.substr(0, actualPath.lastIndexOf("/")).replace('components/', '');
   },
   class: function(modifiedPath) {
-    return this.path(modifiedPath).replace(/\//g, '__');
+    return '_' + this.path(modifiedPath).replace(/\//g, '__');
   }
 };

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ember-cli-babel": "^5.1.5",
     "ember-getowner-polyfill": "1.0.1",
     "fs-tree-diff": "^0.4.4",
+    "md5": "^2.1.0",
     "postcss": "^5.0.19",
     "postcss-selector-namespace": "^1.2.4",
     "rsvp": "^3.2.1",


### PR DESCRIPTION
so as not to conflict with other namespaces addresses #116

this will add a class like `_foo` to the components. 

@ebryn @topaxi @buschtoens care to weigh in? I know that you @ebryn had addressed concerns over predictable, and proposed that we use some type of deterministic hashing algorithm instead. Is that still desired?