### PR TITLE
Filter undefined type extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ module.exports = {
 
   included: function(app) {
     this._super.included.apply(this, arguments);
-    this.appConfig = app.project.config(); 
-    this.allowedStyleExtentions = app.registry.extensionsForType('css');
+    this.appConfig = app.project.config();
+    this.allowedStyleExtentions = app.registry.extensionsForType('css').filter(Boolean);
   },
 
   treeForAddon: function(tree) {


### PR DESCRIPTION
Hi @ebryn; Hi @webark -

We're seeing a small, but blocking issue with release "0.2.0-beta.3". The [first patch](https://github.com/ebryn/ember-component-css/commit/712637e4e352873987f677870de2c2d002645d63) is great and resolves some small styling quirks we were seeing. But, the [second patch](https://github.com/ebryn/ember-component-css/commit/441fa1fb169ebf236834124861f5f53f3b667755) prevents our Ember app from starting.

This is the specific error during `ember s`:
```
The Broccoli Plugin: [PodStyles] failed with:
TypeError: Cannot read property 'length' of undefined
```
It seems the second patch was to use `app.registry.extensionsForType('css')` instead of `this.registry.extensionsForType('css')`. What we're seeing is the previous output from `this.registry.extensionsForType('css')` was `[ 'css', 'styl', 'scss', 'sass' ]`. Whereas the current output from `app.registry.extensionsForType('css')` is `[ 'css', undefined, 'styl', 'scss', 'sass' ]`.

The presence of `undefined` in the extensionsForType array causes the `ember s` error above. This PR is to filter out undefined from the extensions associated with CSS which resolves the error above.

Thanks Everyone!
