### PR TITLE
Using a manifest file for the pod-styles rather then a concatenated file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,8 +64,12 @@ module.exports = {
       });
     }
 
-    podStyles = new IncludeAll(podStyles, {
+    var styleManifest = new IncludeAll(podStyles, {
       annotation: 'IncludeAll (ember-component-css combining all style files that there are extensions for)'
+    });
+
+    podStyles = new Merge([podStyles, styleManifest, tree].filter(Boolean), {
+      annotation: 'Merge (ember-component-css merge namespacedStyles with style manafest)'
     });
 
     return this._super.treeForStyles.call(this, podStyles);

--- a/lib/include-all.js
+++ b/lib/include-all.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var FSTree = require('fs-tree-diff');
 var Promise = require('rsvp').Promise;
 var path = require('path');
-//var os = require("os");
+var os = require("os");
 
 module.exports = IncludeAll;
 
@@ -40,7 +40,6 @@ IncludeAll.prototype.importPods = function(patches, srcDir) {
   for (var i = 0; i < patches.length; i++) {
     switch (patches[i][0]) {
       case 'create':
-      case 'change':
         this.addPod(patches[i][1], srcDir);
         break;
       case 'unlink':
@@ -52,7 +51,7 @@ IncludeAll.prototype.importPods = function(patches, srcDir) {
   for (var extension in this.importedPods) {
     var output = '';
     for (var file in this.importedPods[extension]) {
-      output += this.importedPods[extension][file];// + ';' + os.EOL;
+      output += this.importedPods[extension][file] + ';' + os.EOL;
     }
     fs.writeFileSync(path.join(this.outputPath, 'pod-styles' + extension), output);
   }
@@ -64,13 +63,7 @@ IncludeAll.prototype.addPod = function(stylePath, srcDir) {
   var extension = path.extname(stylePath);
 
   this.importedPods[extension] = this.importedPods[extension] || {};
-
-  // wanted to use an import manifest rather then combining all the files
-  // so that when it goes through it's final css preprocessor stage
-  // it can create the appropriate .map files. Wasn't able to find the file tough..
-  //
-  // this.importedPods[extension][stylePath] = '@import "' + stylePath + '"';
-  this.importedPods[extension][stylePath] = fs.readFileSync(path.join(srcDir, stylePath), "utf8");
+  this.importedPods[extension][stylePath] = '@import "' + stylePath + '"';
 }
 
 IncludeAll.prototype.removePod = function(stylePath) {


### PR DESCRIPTION
Putting this out there for discussion. Major benefits are that we can get more detailed sourcemaps due to each file being imported separately into the manifest file. Also, we only have to modify this file when we add or delete a styles.scss file, not when any css is changed. 

Downsides are that it take a little longer due to the preprocessor having to take the extra weight of importing all the files. More so requires the eventual consumer of this file to be able to import css files in an expected and supported way.

@topaxi @ebryn `@anyonehere` please comment as to any feedback you might have.