### PR TITLE
Moves processing of namespace selectors to postcss for sass and less

### DIFF
--- a/lib/pod-style.js
+++ b/lib/pod-style.js
@@ -27,9 +27,9 @@ PodStyles.prototype.processString = function(contents, stylePath) {
       break;
     case '.less':
     case '.scss':
-      strategy = 'wrap';
+      strategy = 'syntax';
       break;
   }
 
-  return processStratagies[strategy](contents, className);
+  return processStratagies[strategy](contents, className, extension);
 };

--- a/lib/preprocess-class-names.js
+++ b/lib/preprocess-class-names.js
@@ -1,6 +1,18 @@
 var postcss = require('postcss');
 var postcssSelectorNamespace = require('postcss-selector-namespace')
 var os = require('os');
+var supportedExtensions = {
+  ".scss": require('postcss-scss'),
+  ".less": require('postcss-less')
+};
+
+function namespaceSelectors(className) {
+  return postcssSelectorNamespace({
+    selfSelector: /&|:--component/,
+    namespace: '.' + className,
+    ignoreRoot: false
+  });
+}
 
 module.exports = {
   indentation: function(contents, className) {
@@ -20,11 +32,14 @@ module.exports = {
     return '.' + className + '{' + contents + '}';
   },
 
+  syntax: function(contents, className, extension) {
+    return postcss().use(namespaceSelectors(className))
+      .process(contents, {
+        syntax: supportedExtensions[extension]
+      }).css;
+  },
+
   default: function(contents, className) {
-    return postcss().use(postcssSelectorNamespace({
-              selfSelector: /&|:--component/,
-              namespace: '.' + className,
-              ignoreRoot: false
-            })).process(contents).css;
+    return postcss().use(namespaceSelectors(className)).process(contents).css;
   }
 };

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "fs-tree-diff": "^0.5.0",
     "md5": "^2.1.0",
     "postcss": "^5.0.19",
+    "postcss-less": "^0.8.0",
+    "postcss-scss": "^0.1.7",
     "postcss-selector-namespace": "^1.2.4",
     "rsvp": "^3.2.1",
     "walk-sync": "^0.2.6"


### PR DESCRIPTION
This is in lieu of just wrapping them in the namespace. Feel like it's a little cleaner, and less apt to have wacky edgecase errors that might come up by just wrapping the content. Stylus and Sass still are just indenting. 