### PR TITLE
Add component lookup fallback solution

### DIFF
--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -8,6 +8,7 @@ const {
 
 ComponentLookup.reopen({
   componentFor(name, owner) {
+    debugger;
     if (podNames[name] && !owner.hasRegistration('component:' + name)) {
       owner.register('component:' + name, Component);
     }

--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -6,10 +6,17 @@ const {
   ComponentLookup,
 } = Ember;
 
+function hasRegistration(owner, name) {
+  if (owner.hasRegistration) {
+    return owner.hasRegistration(name);
+  } else {
+    return owner._registry.has(name);
+  }
+}
+
 ComponentLookup.reopen({
   componentFor(name, owner) {
-    debugger;
-    if (podNames[name] && !owner.hasRegistration('component:' + name)) {
+    if (podNames[name] && !hasRegistration(owner, 'component:' + name)) {
       owner.register('component:' + name, Component);
     }
     return this._super(...arguments);

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,55 +1,57 @@
 /*jshint node:true*/
-module.exports = {
-  scenarios: [
-    {
-      name: 'default',
-      bower: {
-        dependencies: { }
-      }
-    },
-    {
-      name: 'ember-1-13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
+module.exports = function() {
+  return {
+    scenarios: [
+      {
+        name: 'default',
+        bower: {
+          dependencies: { }
+        }
+      },
+      {
+        name: 'ember-1-13',
+        bower: {
+          dependencies: {
+            'ember': '~1.13.0'
+          },
+          resolutions: {
+            'ember': '~1.13.0'
+          }
+        }
+      },
+      {
+        name: 'ember-release',
+        bower: {
+          dependencies: {
+            'ember': 'components/ember#release'
+          },
+          resolutions: {
+            'ember': 'release'
+          }
+        }
+      },
+      {
+        name: 'ember-beta',
+        bower: {
+          dependencies: {
+            'ember': 'components/ember#beta'
+          },
+          resolutions: {
+            'ember': 'beta'
+          }
+        }
+      },
+      {
+        name: 'ember-canary',
+        bower: {
+          dependencies: {
+            'ember': 'components/ember#canary'
+          },
+          resolutions: {
+            'ember': 'canary'
+          }
         }
       }
-    },
-    {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#release'
-        },
-        resolutions: {
-          'ember': 'release'
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
-          'ember': 'beta'
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
-          'ember': 'canary'
-        }
-      }
-    }
-  ]
+    ]
+  };
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:each"
   },
   "repository": {
     "type": "git",
@@ -39,7 +39,7 @@
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
-    "ember-try": "^0.1.2",
+    "ember-try": "^0.2.2",
     "loader.js": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
I recently upgraded to the latest beta to fix the issue with `app.import` breaking, and found that the use of `owner.hasRegistration` broke Ember 1.13.  I tried to come up with a failing test case, but was unable to do so, because I wasn't able to follow what situations that code was called under.  If you could guide me toward how to make a test case, I'd love to add one, but this at least fixes the issues in my app.