### PR TITLE
Correctly match runtime classnames to path-derived component names

### DIFF
--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -19,7 +19,7 @@ Component.reopen({
   init() {
     this._super(...arguments);
     if (this.get('tagName') !== '' && this._debugContainerKey) {
-      const name = this._debugContainerKey.replace('component:', '');
+      const name = this._debugContainerKey.replace('component:', '').replace('components/', '');
       if (podNames[name]) {
         this.classNames.push(podNames[name]);
       }


### PR DESCRIPTION
In trying to work out why people affected by #121 recovered while I was left without the right in-markup hooks, I realise our slightly unorthodox pod hierarchy has splat namespacing (to deal with the fact we're building several apps in one with concerns of a variety of degrees of isolation) eg `./app/{{esotericNamespace}}/components/{{component-name}}`.

In any case, the 0.2 betas fail to match hooks in the generated CSS and the markup. Upon debug it was clear that there was a mismatch between the name-generation logic in component-styles and component-names (specifically, [this line](https://github.com/ebryn/ember-component-css/blob/528dbd377a87bf71b40090233cbabe4630d9b482/lib/component-names.js#L5)).