### PR TITLE
Support for use inside of addons.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var IncludeAll = require('./lib/include-all.js');
 module.exports = {
 
   _getPodStyleFunnel: function() {
-    return new Funnel('app', {
+    return new Funnel(this.projectRoot, {
       srcDir: this._podDirectory(),
       exclude: ['styles/**/*'],
       include: ['**/*.{' + this.allowedStyleExtensions + '}'],
@@ -29,9 +29,17 @@ module.exports = {
   },
 
   included: function(app) {
+    if (app.app) { app = app.app; }
+
     this._super.included.apply(this, arguments);
-    this.appConfig = app.project.config();
-    this.addonConfig = this.app.project.config(app.env)['ember-component-css'] || {};
+
+    this.projectRoot = Merge([app.trees.app].concat(app.addonTreesFor('app')), {
+      overwrite: true,
+      annotation: 'Merge (merging addons app namespace in)'
+    });
+    this.appName = app.project.name();
+    this.appConfig = app.project.config(app.env);
+    this.addonConfig = this.appConfig['ember-component-css'] || {};
     this.allowedStyleExtensions = app.registry.extensionsForType('css').filter(Boolean);
   },
 


### PR DESCRIPTION
needing to base the configs off of the passed in app.

Also, including all of the addon's app space in the main funnel. This is a start to fixing #143 

One caveat with this is that in order to use it in the addon, you have to put the styles inside the app directories rather then the addon, and ALL podstyles get bundled together. Meaning from both your apps and your addons all in the same pod-styles files.