### PR TITLE
Add support for custom vendor.js paths

### DIFF
--- a/lib/component-css-postprocessor.js
+++ b/lib/component-css-postprocessor.js
@@ -24,6 +24,10 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
   var pod = this.options.addon.pod;
   var hashFn = this.inputTree['inputTree'] && this.inputTree['inputTree'].hashFn;
   var reopenScript = this.reopenScript;
+  var vendorjsPath = this.options.addon.app.options &&
+    this.options.addon.app.options.outputPaths &&
+    this.options.addon.app.options.outputPaths.vendor &&
+    this.options.addon.app.options.outputPaths.vendor.js || null;
 
   return readTree(this.inputTree).then(function(srcDir) {
     var paths = walkSync(srcDir);
@@ -41,9 +45,14 @@ ComponentCssPostprocessor.prototype.write = function (readTree, destDir) {
     var cssInjectionSource =' \n\nEmber.COMPONENT_CSS_LOOKUP = ' + JSON.stringify(pod.lookup) + ';\n' + reopenScript;
 
     // Find the vendor.js file in assets so we can append the component lookup JS
-    var assetFiles = fs.readdirSync(path.join(destDir, 'assets'));
-    var vendorjs = assetFiles.filter(function(i){ return i.match(/vendor.*?\.js/); })[0];
-    var vendorjsPath = path.join(destDir, 'assets', vendorjs);
+    if (vendorjsPath) {
+      vendorjsPath = path.join(destDir, vendorjsPath);
+    } else {
+      var assetFiles = fs.readdirSync(path.join(destDir, 'assets'));
+      var vendorjs = assetFiles.filter(function(i){ return i.match(/vendor.*?\.js/); })[0];
+      vendorjsPath = path.join(destDir, 'assets', vendorjs);
+    }
+
     // FIXME: This is a quick and ugly workaround to fix #114
     if (fs.readFileSync(vendorjsPath).toString().indexOf('Ember.COMPONENT_CSS_LOOKUP') === -1) {
       fs.appendFileSync(vendorjsPath, cssInjectionSource);


### PR DESCRIPTION
Adds support for custom vendor.js output paths specified in ember-cli-build.js (outputPaths). Fixes ebryn/ember-component-css#159