### PR TITLE
updated the BEM tests

### DIFF
--- a/tests/acceptance/less-test.js
+++ b/tests/acceptance/less-test.js
@@ -29,18 +29,18 @@ test('non class nested rule followed', function(assert) {
   });
 });
 
-test('BES rule followed', function(assert) {
+test('BEM rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes').css('color'), 'rgb(0, 0, 4)');
+    assert.equal(find('[class$=-element]').css('color'), 'rgb(0, 0, 4)');
   });
 });
 
-test('BES variant rule followed', function(assert) {
+test('BEM variant rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes_variant').css('color'), 'rgb(0, 0, 5)');
+    assert.equal(find('[class$=-element_variant]').css('color'), 'rgb(0, 0, 5)');
   });
 });

--- a/tests/acceptance/sass-test.js
+++ b/tests/acceptance/sass-test.js
@@ -29,18 +29,18 @@ test('non class nested rule followed', function(assert) {
   });
 });
 
-test('BES rule followed', function(assert) {
+test('BEM rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes').css('color'), 'rgb(0, 0, 4)');
+    assert.equal(find('[class$=-element]').css('color'), 'rgb(0, 0, 4)');
   });
 });
 
-test('BES variant rule followed', function(assert) {
+test('BEM variant rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes_variant').css('color'), 'rgb(0, 0, 5)');
+    assert.equal(find('[class$=-element_variant]').css('color'), 'rgb(0, 0, 5)');
   });
 });

--- a/tests/acceptance/scss-test.js
+++ b/tests/acceptance/scss-test.js
@@ -29,18 +29,18 @@ test('non class nested rule followed', function(assert) {
   });
 });
 
-test('BES rule followed', function(assert) {
+test('BEM rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes').css('color'), 'rgb(0, 0, 4)');
+    assert.equal(find('[class$=-element]').css('color'), 'rgb(0, 0, 4)');
   });
 });
 
-test('BES variant rule followed', function(assert) {
+test('BEM variant rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes_variant').css('color'), 'rgb(0, 0, 5)');
+    assert.equal(find('[class$=-element_variant]').css('color'), 'rgb(0, 0, 5)');
   });
 });

--- a/tests/acceptance/styl-test.js
+++ b/tests/acceptance/styl-test.js
@@ -29,18 +29,18 @@ test('non class nested rule followed', function(assert) {
   });
 });
 
-test('BES rule followed', function(assert) {
+test('BEM rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes').css('color'), 'rgb(0, 0, 4)');
+    assert.equal(find('[class$=-element]').css('color'), 'rgb(0, 0, 4)');
   });
 });
 
-test('BES variant rule followed', function(assert) {
+test('BEM variant rule followed', function(assert) {
   visit('/' + TYPE);
 
   andThen(function() {
-    assert.equal(find('.base-bes_variant').css('color'), 'rgb(0, 0, 5)');
+    assert.equal(find('[class$=-element_variant]').css('color'), 'rgb(0, 0, 5)');
   });
 });

--- a/tests/dummy/app/components/base-rules/component.js
+++ b/tests/dummy/app/components/base-rules/component.js
@@ -2,5 +2,5 @@ import Ember from 'ember';
 import layout from './template';
 
 export default Ember.Component.extend({
-  layout
+  layout,
 });

--- a/tests/dummy/app/components/base-rules/template.hbs
+++ b/tests/dummy/app/components/base-rules/template.hbs
@@ -4,5 +4,5 @@
     </span>
   </span>
 </span>
-<span class="base-bes"></span>
-<span class="base-bes_variant"></span>
+<span class="{{componentCssClassName}}-element"></span>
+<span class="{{componentCssClassName}}-element_variant"></span>

--- a/tests/dummy/app/components/less/base-rules/styles.less
+++ b/tests/dummy/app/components/less/base-rules/styles.less
@@ -4,20 +4,22 @@
   .nested {
     color: rgb(0, 0, 2);
   }
-
-  &-bes {
-    color: rgb(0, 0, 4);
-
-    &_variant {
-      color: rgb(0, 0, 5);
-    }
-  }
 }
 
 span {
   > span {
     > span {
       color: rgb(0, 0, 3);
+    }
+  }
+}
+
+& {
+  &-element {
+    color: rgb(0, 0, 4);
+
+    &_variant {
+      color: rgb(0, 0, 5);
     }
   }
 }

--- a/tests/dummy/app/components/sass/base-rules/styles.sass
+++ b/tests/dummy/app/components/sass/base-rules/styles.sass
@@ -4,13 +4,14 @@
   .nested
     color: rgb(0, 0, 2)
 
-  &-bes
-    color: rgb(0, 0, 4)
-
-    &_variant
-      color: rgb(0, 0, 5)
-
 span
   > span
     > span
       color: rgb(0, 0, 3)
+
+&
+  &-element
+    color: rgb(0, 0, 4)
+
+    &_variant
+      color: rgb(0, 0, 5)

--- a/tests/dummy/app/components/scss/base-rules/styles.scss
+++ b/tests/dummy/app/components/scss/base-rules/styles.scss
@@ -4,20 +4,22 @@
   .nested {
     color: rgb(0, 0, 2);
   }
-
-  &-bes {
-    color: rgb(0, 0, 4);
-
-    &_variant {
-      color: rgb(0, 0, 5);
-    }
-  }
 }
 
 span {
   > span {
     > span {
       color: rgb(0, 0, 3);
+    }
+  }
+}
+
+& {
+  &-element {
+    color: rgb(0, 0, 4);
+
+    &_variant {
+      color: rgb(0, 0, 5);
     }
   }
 }

--- a/tests/dummy/app/components/styl/base-rules/styles.styl
+++ b/tests/dummy/app/components/styl/base-rules/styles.styl
@@ -4,13 +4,14 @@
   .nested
     color rgb(0, 0, 2)
 
-  &-bes
-    color rgb(0, 0, 4)
-
-    &_variant
-      color rgb(0, 0, 5)
-
 span
   > span
     > span
       color rgb(0, 0, 3)
+
+&
+  &-element
+    color rgb(0, 0, 4)
+
+    &_variant
+      color rgb(0, 0, 5)


### PR DESCRIPTION
Updated these to be a better use case. We now have access to the `componentCssClassName` variable. We can use this variable in the templates to facilitate basic BEM css definitions.

Would like to add in the ability to make this more seamless in the future, and add to docs.