### PR TITLE
Default empty pod name file

### DIFF
--- a/addon/pod-names.js
+++ b/addon/pod-names.js
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
This addresses #184. By creating a empty pod-name file, the file is guaranteed to alway be there, even if we don't want it like in the case of turning off name-spacing.