### PR TITLE
Support in-repo engines dependent on in-repo addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = {
 
     this._super.included.apply(this, arguments);
 
-    this.projectRoot = app.trees.app;
+    if (app.trees) {
+      this.projectRoot = app.trees.app;
+    }
 
     if (this._isAddon()) {
       this.parent.treeForMethods['addon-styles'] = 'treeForParentAddonStyles';

--- a/index.js
+++ b/index.js
@@ -33,19 +33,29 @@ module.exports = {
 
   _allPodStyles: [],
 
+  _projectRoot: function(trees) {
+    var projectRoot;
+    if (this._isAddon()) {
+      projectRoot = this.parent.root + '/addon';
+    } else if (trees && trees.app) {
+      projectRoot = trees.app;
+    } else {
+      projectRoot = this.parent.root + '/app';
+    }
+
+    return projectRoot;
+  },
+
   included: function(app) {
     if (app.app) { app = app.app; }
 
     this._super.included.apply(this, arguments);
 
-    if (app.trees) {
-      this.projectRoot = app.trees.app;
-    }
+    this.projectRoot = this._projectRoot(app.trees);
 
     if (this._isAddon()) {
       this.parent.treeForMethods['addon-styles'] = 'treeForParentAddonStyles';
       this.parent.treeForParentAddonStyles = this.treeForParentAddonStyles.bind(this);
-      this.projectRoot = this.parent.root + '/addon';
     }
 
     this.appConfig = app.project.config(app.env);


### PR DESCRIPTION
We are using ember-component-css in conjunction with ember-engines. Our engines are in-repo addons, and we have an additional in-repo addon for our app that contains shared components to be consumed by both the main app and the in-repo engines.

This pattern works fine except that currently ember-cli will throw an error in the `included` hook for the addon: `Cannot read property app of undefined`. I have a repro ember-cli repo here:
https://github.com/sohara/in-repo-component-css

This patch is simple guard agains accessing nested props on `app` that are not defined, but perhaps there's a better guard or other approach.