### PR TITLE
Setting `classNames` in stead of modifying it

### DIFF
--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -38,7 +38,7 @@ Component.reopen({
     const name = this.get('componentCssClassName');
 
     if (this.get('tagName') !== '' && name) {
-      this.classNames.push(name);
+      this.classNames = [name].pushObjects(this.classNames);
     }
   }
 });


### PR DESCRIPTION
This should fix #193 on Ember Canary 2.9.0

In Ember 2.9.0 the component className is a sealed argument so it can not be modified. To add the `componentCssClassName` it has to be set in stead of modified with `push()`.