### PR TITLE
moving to concatenating and reassigning the classname…

### DIFF
--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -33,13 +33,13 @@ Component.reopen({
   }),
 
   init() {
+    this._super(...arguments);
+
     let name = this.get('componentCssClassName');
 
     if (this.get('tagName') !== '' && name) {
-      this.classNames = [name];
+      this.classNames = this.classNames.concat(name);
     }
-
-    this._super(...arguments);
   }
 });
 


### PR DESCRIPTION
incase a classname is already in the array before the init call per @rwjblue suggestion.

Also moving the super call back to the top just for safe keeping.