### PR TITLE
Moving namespacing extras to service for easier extending

### DIFF
--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -6,6 +6,7 @@ const {
   Component,
   ComponentLookup,
   computed,
+  inject,
 } = Ember;
 
 ComponentLookup.reopen({
@@ -20,9 +21,11 @@ ComponentLookup.reopen({
 });
 
 Component.reopen({
+  _componentNamespacingExtras: inject.service('component-namespacing-extras'),
+
   _componentIdentifier: computed({
     get() {
-      return (this._debugContainerKey || '').replace('component:', '');
+      return this.get('_componentNamespacingExtras').componentIdentifier(this._debugContainerKey);
     }
   }),
 

--- a/addon/services/component-namespacing-extras.js
+++ b/addon/services/component-namespacing-extras.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const {
+  Service,
+} = Ember;
+
+export default Service.extend({
+  componentIdentifier(_debugContainerKey) {
+    return (_debugContainerKey || '').replace('component:', '');
+  }
+});

--- a/app/services/component-namespacing-extras.js
+++ b/app/services/component-namespacing-extras.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-component-css/services/component-namespacing-extras';


### PR DESCRIPTION
Moving some functionality of creating the namespacing to a service, so that if you need to overwrite it, it's much easier then if it's just raw in an initializer.

This is just an idea, would like a little bit of feedback around it. Was initially done to address #165 and @toranb use case. 