### PR TITLE
Update ember-getowner-polyfill to avoid deprecation warnings

### DIFF
--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import podNames from 'ember-component-css/pod-names';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   Component,
   ComponentLookup,
   computed,
+  getOwner
 } = Ember;
 
 ComponentLookup.reopen({

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "broccoli-persistent-filter": "^1.2.6",
     "broccoli-plugin": "^1.2.1",
     "ember-cli-babel": "^5.1.7",
-    "ember-getowner-polyfill": "^1.0.1",
+    "ember-getowner-polyfill": "^1.1.1",
     "fs-tree-diff": "^0.5.4",
     "md5": "^2.1.0",
     "postcss": "^5.2.6",


### PR DESCRIPTION
The polyfill is now available through the Ember object, no need to import it anymore!