### PR TITLE
Fixing an oddity in the glob syntax for including files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
     return new Funnel(this.projectRoot, {
       srcDir: this._podDirectory(),
       exclude: ['styles/**/*'],
-      include: ['**/*.{' + this.allowedStyleExtensions + '}'],
+      include: ['**/*.{' + this.allowedStyleExtensions + ',}'],
       allowEmpty: true,
       annotation: 'Funnel (ember-component-css grab files)'
     });


### PR DESCRIPTION
Due to the odd nature of 'glob', you can't have a set of just one item. So adding an extra ',' at the end so that you will always have at least two "items" in the set

Closes #178, #204