### PR TITLE
updated broccoli style manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-persistent-filter": "^1.4.2",
     "broccoli-plugin": "^1.3.0",
-    "broccoli-style-manifest": "^1.3.1",
+    "broccoli-style-manifest": "^1.4.0",
     "ember-cli-babel": "^6.6.0",
     "ember-getowner-polyfill": "^2.0.1",
     "fs-tree-diff": "^0.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,9 +1346,9 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
-broccoli-style-manifest@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/broccoli-style-manifest/-/broccoli-style-manifest-1.3.1.tgz#2754c6010ec7bdde5b8a4f2ef988d75eccce032d"
+broccoli-style-manifest@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/broccoli-style-manifest/-/broccoli-style-manifest-1.4.0.tgz#4b805121f98bb246568f55d1620240c73dab3ec5"
   dependencies:
     broccoli-plugin "^1.3.0"
     fs-tree-diff "^0.5.6"


### PR DESCRIPTION
Now the order of files in the manifest is sorted first by depth, then by alphanumeric.