### PR TITLE
Fixes a namespacing issue when using yarn link

### DIFF
--- a/app/initializers/component-styles.js
+++ b/app/initializers/component-styles.js
@@ -2,7 +2,7 @@ export { default, initialize } from 'ember-component-css/initializers/component-
 
 import Ember from 'ember';
 
-import StyleNamespacingExtras from '../mixins/style-namespacing-extras';
+import StyleNamespacingExtras from 'ember-component-css/mixins/style-namespacing-extras';
 
 // eslint-disable-next-line ember/new-module-imports
 Ember.Component.reopen(StyleNamespacingExtras);


### PR DESCRIPTION
Got this error when i linked a engine that uses ember-component-css (experimental)
Error: Could not find module `my-engine/mixins/style-namespacing-extras` imported from `my-engine/initializers/component-styles`