### PR TITLE
Support component-css in addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports = {
     });
 
     var styleManifest = new StyleManifest(podStylesWithoutExcluded, {
-      outputFileNameWithoutExtension: 'pod-styles',
+      outputFileNameWithoutExtension: this._isAddon() ? this.parent.name + '-pod-styles' : 'pod-styles',
       annotation: 'StyleManifest (ember-component-css combining all style files that there are extensions for)'
     });
 

--- a/tests/dummy/lib/second-test-addon/addon/styles/addon.less
+++ b/tests/dummy/lib/second-test-addon/addon/styles/addon.less
@@ -1,1 +1,1 @@
-@import 'pod-styles';
+@import 'second-test-addon-pod-styles';

--- a/tests/dummy/lib/test-addon/addon/styles/addon.scss
+++ b/tests/dummy/lib/test-addon/addon/styles/addon.scss
@@ -1,1 +1,1 @@
-@import 'pod-styles.scss';
+@import 'test-addon-pod-styles.scss';


### PR DESCRIPTION
To support multiple ember-component-css instances. Currently the `pod-styles` file gets overwritten by other `pod-styles` file from other addons or conflict with the parent project...
This will allow for each addon to create its own `<addon-name>-pod-styles`.
Then the parent addon can include it in the scss, or the addon itself  can also already include it in its own <addon>.scss.

alternative to https://github.com/ebryn/ember-component-css/pull/277 ?