### PR TITLE
gaurding against transitions without a 'to'

### DIFF
--- a/addon/instance-initializers/route-styles.js
+++ b/addon/instance-initializers/route-styles.js
@@ -18,8 +18,11 @@ export function initialize(appInstance) {
   });
 }
 
-function nestedRouteNames(route, routeNames = []) {
-  routeNames.push(route.name);
+function nestedRouteNames(route = {}, routeNames = []) {
+  if (route.name) {
+    routeNames.push(route.name);
+  }
+
   if (route.parent) {
     return nestedRouteNames(route.parent, routeNames);
   }


### PR DESCRIPTION
When aborting a transition on an initial load where the transition's `from` is `null` the router sets the `to` the `from` of the transition you where coming from. Putting a guard against this null `to` value now.


fixes #323 