### PR TITLE
'ComponentLookup' class as removed from the 'Ember' namespace

### DIFF
--- a/addon/initializers/component-styles.js
+++ b/addon/initializers/component-styles.js
@@ -1,25 +1,8 @@
-import Ember from "ember";
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import { getOwner } from '@ember/application';
 
 import podNames from 'ember-component-css/pod-names';
-
-const {
-  ComponentLookup,
-} = Ember;
-
-ComponentLookup.reopen({
-  componentFor(name, owner) {
-    owner = owner.hasRegistration ? owner : getOwner(this);
-
-    if (podNames[name] && !owner.hasRegistration(`component:${name}`)) {
-      owner.register(`component:${name}`, Component);
-    }
-    return this._super(...arguments);
-  },
-});
 
 Component.reopen({
   _componentIdentifier: computed({

--- a/addon/instance-initializers/component-styles.js
+++ b/addon/instance-initializers/component-styles.js
@@ -1,0 +1,23 @@
+
+import Component from '@ember/component';
+import { getOwner } from '@ember/application';
+
+import podNames from 'ember-component-css/pod-names';
+
+export function initialize(appInstance) {
+  let componentLookup = appInstance.lookup('component-lookup:main');
+  const originalComponentFor = componentLookup.componentFor;
+
+  componentLookup.componentFor = function(name, owner) {
+    owner = owner.hasRegistration ? owner : getOwner(this);
+
+    if (podNames[name] && !owner.hasRegistration(`component:${name}`)) {
+      owner.register(`component:${name}`, Component);
+    }
+    return originalComponentFor(...arguments);
+  };
+}
+
+export default {
+  initialize
+};

--- a/app/instance-initializers/component-styles.js
+++ b/app/instance-initializers/component-styles.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-component-css/instance-initializers/component-styles';

--- a/testem.js
+++ b/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
FIXES: #335

Still using the same api, but moving it to basing it off of the registry. This could break in the future, but gives us time to investigate another fix until the 1.0 can be released.