### PR TITLE
Support colocated components

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ let VersionChecker = require("ember-cli-version-checker");
 module.exports = {
 
   _getStyleFunnel: function() {
-    return new Merge([this._getPodStyleFunnel(), this._getClassicStyleFunnel()], {
+    return new Merge([this._getPodStyleFunnel(), this._getClassicStyleFunnel(),this._getColocatedComponentsStyleFunnel()], {
       annotation: 'Merge (ember-component-css merge pod and classic styles)'
     });
   },
@@ -31,6 +31,15 @@ module.exports = {
       include: ['styles/' + this.classicStyleDir + '/**/*.{' + this.allowedStyleExtensions + ',}'],
       allowEmpty: true,
       annotation: 'Funnel (ember-component-css grab classic files)'
+    });
+  },
+
+  _getColocatedComponentsStyleFunnel: function() {
+    return new Funnel(this.projectRoot, {
+      srcDir: 'components',
+      include: ['**/*.{' + this.allowedStyleExtensions + ',}'],
+      allowEmpty: true,
+      annotation: 'Funnel (ember-component-css grab colocated components files)'
     });
   },
 

--- a/lib/component-names.js
+++ b/lib/component-names.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var md5 = require('md5');
+var path = require('path');
 
 module.exports = {
   path: function(actualPath, classicStyleDir) {
@@ -11,7 +12,12 @@ module.exports = {
     if (actualPath.includes(classicStyleDir)) {
       terminator = '.';
       pathSegementToRemove = 'styles/' + classicStyleDir + '/';
-    }
+    } else { // Colocated component stylesheet
+      var pathInfo = path.parse(actualPath);
+      if (pathInfo.name !== 'styles') {
+        terminator = '.';
+      }  
+    } 
 
     return actualPath.substr(0, actualPath.lastIndexOf(terminator)).replace(pathSegementToRemove, '');
   },


### PR DESCRIPTION
Added support for colocating the styles.css files in the components directory with the template and js files i.e.

components./my-component.hbs
components/my-component.js
components/my-component.css

No tests have been written because I do not know how to do them properly in an addon. Need to read more but need to fix this first.