### PR TITLE
Allow to opt out of classic component patching

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,9 +132,22 @@ module.exports = {
         annotation: 'Merge (ember-component-css merge names with addon tree)'
       });
     }
+
     let checker = new VersionChecker(this);
     let ember = checker.forEmber();
     let superTree = this._super.treeForAddon.call(this, tree);
+
+    // Allow to opt-out from automatic Component.reopen()
+    if (this.addonConfig.patchClassicComponent === false) {
+      superTree = new Funnel(superTree, {
+        exclude: [
+          'ember-component-css/initializers/component-styles.js'
+        ],
+        annotation:
+          "Funnel (ember-component-css exclude addon/initializers/component-styles.js per config)"
+      });
+    }
+
     if (ember.isAbove('3.6.0')) {
       return new Funnel(superTree, {
         exclude: ['ember-component-css/initializers/route-styles.js'],
@@ -151,6 +164,17 @@ module.exports = {
   },
 
   treeForApp: function(tree) {
+    // Allow to opt-out from automatic Component.reopen()
+    if (this.addonConfig.patchClassicComponent === false) {
+      tree = new Funnel(tree, {
+        exclude: [
+          "initializers/component-styles.js"
+        ],
+        annotation:
+          "Funnel (ember-component-css exclude app/initializers/component-styles.js per config)"
+      });
+    }
+
     let checker = new VersionChecker(this);
     let ember = checker.forEmber();
     if (ember.isAbove('3.6.0')) {


### PR DESCRIPTION
opt-in to address #365 until [ember-cli-styles](https://github.com/webark/ember-cli-styles) has stable release.

This would allow you to specify in `config/environment.js`:

```js
'ember-component-css': {
  patchClassicComponent: false
}
```

Avoid the deprecation `Reopening the Ember.Component super class itself is deprecated` if you do not use classic components (or the bindings on classic components, at least).

Similar to https://github.com/salsify/ember-css-modules/pull/251 and https://github.com/simplabs/ember-test-selectors/pull/721.